### PR TITLE
Removed 'moves.remove()' in search(), now the goal is always found

### DIFF
--- a/AStar.java
+++ b/AStar.java
@@ -66,8 +66,6 @@ public class AStar {
 
                 /* If adjacent node is already in closed set... */
                 if (closed.contains(adjNode)) {
-                    /* Discard move. */ 
-                    moves.remove(adjNode);
                     /* Continue next iteration of for loop. */
                     continue;
                 }


### PR DESCRIPTION
I removed a line in the search() method for AStar.java that would remove a state from the moves ArrayList.  I think it was causing problems because the for loop surrounding the statement was using moves.size() as the boundary for i, and the remove() method was altering the moves array in the middle of the loop.
